### PR TITLE
Fix Android rest timer overlay rendering

### DIFF
--- a/apps/mobile/components/RestTimer.tsx
+++ b/apps/mobile/components/RestTimer.tsx
@@ -78,24 +78,86 @@ export const RestTimer = () => {
 
   if (!isActive && !isCompleted) return null;
 
+  const containerStyle = [
+    styles.container,
+    {
+      paddingTop: insets.top,
+      height: insets.top + REST_TIMER_HEIGHT,
+      backgroundColor: isAndroid
+        ? isDark
+          ? "rgba(15,23,42,0.9)"
+          : "rgba(255,255,255,0.9)"
+        : isDark
+          ? "rgba(15,23,42,0.5)"
+          : "rgba(255,255,255,0.5)",
+      borderBottomColor: theme.border,
+    },
+  ];
+
+  if (isAndroid) {
+    return (
+      <View style={containerStyle}>
+        {/* Progress Bar Background */}
+        <View style={[styles.progressBarBg, { backgroundColor: theme.muted }]}>
+          <View
+            style={[
+              styles.progressBarFill,
+              { width: `${fillPercentage}%`, backgroundColor: color },
+            ]}
+          />
+        </View>
+
+        <View style={styles.content}>
+          {/* Time Display */}
+          <Text style={[styles.timerText, { color: theme.text }]}>
+            {formatTime(remainingTime)}
+          </Text>
+
+          {/* Controls */}
+          <View style={styles.controls}>
+            {/* +30s */}
+            <TouchableOpacity
+              onPress={() => addTime(30)}
+              style={styles.iconButton}
+            >
+              <Text style={[styles.addTimeText, { color: theme.text }]}>
+                +30s
+              </Text>
+            </TouchableOpacity>
+
+            {/* Pause/Play */}
+            <TouchableOpacity
+              onPress={isPaused ? resumeTimer : pauseTimer}
+              style={styles.iconButton}
+            >
+              <Ionicons
+                name={isPaused ? "play" : "pause"}
+                size={24}
+                color={theme.text}
+              />
+            </TouchableOpacity>
+
+            {/* Reset */}
+            <TouchableOpacity onPress={resetTimer} style={styles.iconButton}>
+              <Ionicons name="refresh" size={24} color={theme.text} />
+            </TouchableOpacity>
+
+            {/* Cancel */}
+            <TouchableOpacity onPress={cancelTimer} style={styles.iconButton}>
+              <Ionicons name="close" size={24} color={theme.danger} />
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <BlurView
       intensity={50}
       experimentalBlurMethod="dimezisBlurView"
       tint={isDark ? "systemThickMaterialDark" : "systemThickMaterialLight"}
-      style={[
-        styles.container,
-        {
-          paddingTop: insets.top,
-          height: insets.top + REST_TIMER_HEIGHT,
-          backgroundColor: isAndroid
-            ? "transparent" // Ensure transparency on Android for blur to work
-            : isDark
-              ? "rgba(15,23,42,0.5)"
-              : "rgba(255,255,255,0.5)",
-          borderBottomColor: theme.border,
-        },
-      ]}
+      style={containerStyle}
     >
       {/* Progress Bar Background */}
       <View style={[styles.progressBarBg, { backgroundColor: theme.muted }]}>


### PR DESCRIPTION
### Motivation
- The in-app rest timer could leave a white/opaque overlay that visually covered page content when active, particularly on Android devices using `BlurView`.
- The issue appeared only while navigating and was hard to reproduce because inspecting the DOM caused re-renders that masked the problem.
- A platform-specific rendering approach is needed to avoid blur-related overlay rendering bugs on Android while preserving the intended glass-like appearance.

### Description
- Extracted a shared `containerStyle` and switched to a platform conditional render path for the timer container.
- On Android the component now renders a plain `View` (fallback) instead of `BlurView` to avoid blur overlay issues while keeping the same layout and controls.
- Tuned Android background opacity to a more solid `rgba(...,0.9)` to retain a glass-like look without relying on blur.
- Kept the progress bar, time display, and control buttons unchanged and reused in both render paths.

### Testing
- No automated tests were run for this change.
- (Manual QA / runtime verification not listed because only automated test reporting is required.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b9b6626e48323b0b7cc5ce4ada5b6)